### PR TITLE
Allow Panel To Render In Async Environments

### DIFF
--- a/mail_panel/panels.py
+++ b/mail_panel/panels.py
@@ -25,6 +25,7 @@ class MailToolbarPanel(Panel):
     template = 'mail_panel/panel.html'
     has_content = True
     mail_list = OrderedDict()
+    is_async = True
 
     @property
     def scripts(self):


### PR DESCRIPTION
By adding `is_async = True`, we allow the panel to render in async environments.
It would be nice to have the panel support more async workflows (like refreshing the mail items each time it is opened) like Django Debug Toolbar's History panel, but that would require a lot more work. Maybe that can be added in the future.